### PR TITLE
feat: migrate logging stack to Loki + Grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 *.sln
 *.sw?
 *:Zone.Identifier
+
+# Git worktrees
+.worktrees

--- a/apps/base/apps/kustomization.yaml
+++ b/apps/base/apps/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
   - auth/
   - web/
-  - elasticsearch/

--- a/apps/base/middleware/fluent-bit/configmap.yaml
+++ b/apps/base/middleware/fluent-bit/configmap.yaml
@@ -39,16 +39,6 @@ data:
         K8S-Logging.Exclude Off
 
     [OUTPUT]
-        Name            es
-        Match           *
-        Host            elasticsearch.revieu-prod.svc.cluster.local
-        Port            9200
-        Logstash_Format On
-        Retry_Limit     False
-        Replace_Dots    On
-        Suppress_Type_Name On
-
-    [OUTPUT]
         Name            loki
         Match           *
         Host            loki.logging.svc.cluster.local

--- a/apps/base/middleware/fluent-bit/configmap.yaml
+++ b/apps/base/middleware/fluent-bit/configmap.yaml
@@ -48,6 +48,14 @@ data:
         Replace_Dots    On
         Suppress_Type_Name On
 
+    [OUTPUT]
+        Name            loki
+        Match           *
+        Host            loki.logging.svc.cluster.local
+        Port            3100
+        Labels          job=fluent-bit
+        Auto_Kubernetes_Labels on
+
   parsers.conf: |
     [PARSER]
         Name        docker

--- a/apps/base/middleware/grafana/certificate.yaml
+++ b/apps/base/middleware/grafana/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana-cert
+spec:
+  secretName: grafana-tls-secret
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "grafana.weijun.online"

--- a/apps/base/middleware/grafana/configmap-datasources.yaml
+++ b/apps/base/middleware/grafana/configmap-datasources.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.logging.svc.cluster.local:3100
+        isDefault: true
+        editable: false

--- a/apps/base/middleware/grafana/deployment.yaml
+++ b/apps/base/middleware/grafana/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/component: logging
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.2
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: admin-user
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: admin-password
+            - name: GF_SERVER_ROOT_URL
+              value: "https://grafana.weijun.online"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: storage
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: storage
+          persistentVolumeClaim:
+            claimName: grafana-storage

--- a/apps/base/middleware/grafana/ingress.yaml
+++ b/apps/base/middleware/grafana/ingress.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  tls:
+    - hosts:
+        - grafana.weijun.online
+      secretName: grafana-tls-secret
+  rules:
+    - host: grafana.weijun.online
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 80

--- a/apps/base/middleware/grafana/kustomization.yaml
+++ b/apps/base/middleware/grafana/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: logging
+resources:
+  - configmap-datasources.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - certificate.yaml

--- a/apps/base/middleware/grafana/pvc.yaml
+++ b/apps/base/middleware/grafana/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-storage
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/base/middleware/grafana/service.yaml
+++ b/apps/base/middleware/grafana/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: grafana

--- a/apps/base/middleware/kustomization.yaml
+++ b/apps/base/middleware/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - cert-manager/
   - fluent-bit/
-  - kibana/
   - loki/
   - grafana/
   - traefik/

--- a/apps/base/middleware/kustomization.yaml
+++ b/apps/base/middleware/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - cert-manager/
   - fluent-bit/
   - kibana/
+  - loki/
+  - grafana/
   - traefik/
   - sealed-secrets/

--- a/apps/base/middleware/loki/configmap.yaml
+++ b/apps/base/middleware/loki/configmap.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+    common:
+      path_prefix: /loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        cache_location: /loki/index_cache
+        shared_store: filesystem
+      filesystem:
+        directory: /loki/chunks
+    limits_config:
+      retention_period: 72h
+      max_query_lookback: 72h
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 6
+    chunk_store_config:
+      max_look_back_period: 72h
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 72h
+    compactor:
+      working_directory: /loki/compactor
+      shared_store: filesystem
+      retention_enabled: true
+      retention_delete_delay: 2h

--- a/apps/base/middleware/loki/kustomization.yaml
+++ b/apps/base/middleware/loki/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: logging
+resources:
+  - configmap.yaml
+  - service.yaml
+  - statefulset.yaml

--- a/apps/base/middleware/loki/service.yaml
+++ b/apps/base/middleware/loki/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+    - name: grpc
+      port: 9096
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: loki

--- a/apps/base/middleware/loki/statefulset.yaml
+++ b/apps/base/middleware/loki/statefulset.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/component: logging
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.6
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - name: http
+              containerPort: 3100
+            - name: grpc
+              containerPort: 9096
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/overlays/prod/kustomization.yaml
+++ b/apps/overlays/prod/kustomization.yaml
@@ -7,6 +7,5 @@ resources:
   - ./common
   - ./apps/auth
   - ./apps/web
-  - ./apps/elasticsearch
   - ./external/postgres
   - ./middleware

--- a/apps/overlays/prod/middleware/grafana/kustomization.yaml
+++ b/apps/overlays/prod/middleware/grafana/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/middleware/grafana
+  - secret.yaml

--- a/apps/overlays/prod/middleware/grafana/secret.yaml
+++ b/apps/overlays/prod/middleware/grafana/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin
+  namespace: logging
+type: Opaque
+stringData:
+  admin-user: admin
+  admin-password: change-me-please

--- a/apps/overlays/prod/middleware/kustomization.yaml
+++ b/apps/overlays/prod/middleware/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 resources:
   - cert-manager/
   - fluent-bit/
-  - kibana/
   - loki/
   - grafana/
   - traefik/

--- a/apps/overlays/prod/middleware/kustomization.yaml
+++ b/apps/overlays/prod/middleware/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - cert-manager/
   - fluent-bit/
   - kibana/
+  - loki/
+  - grafana/
   - traefik/
   - sealed-secrets/

--- a/docs/plans/2026-01-31-logging-stack-migration-design.md
+++ b/docs/plans/2026-01-31-logging-stack-migration-design.md
@@ -1,0 +1,183 @@
+# Logging Stack Migration: ELK to Loki + Grafana
+
+**Date:** 2026-01-31
+**Status:** Approved
+**Author:** Claude Code
+
+## Problem Statement
+
+Current logging stack (Elasticsearch + Kibana + Fluent-bit) consumes 1.6-3.3GB memory on a 6GB VPS, making deployment impossible. Need a lightweight alternative that:
+- Uses <1GB memory total
+- Provides web UI for log search and viewing
+- Handles 4-10 microservices
+- Retains logs for 1-3 days (debugging use case)
+
+## Solution: Grafana Loki + Grafana
+
+Replace ELK stack with Grafana Loki for log aggregation and Grafana for visualization.
+
+### Architecture
+
+**Components:**
+- **Grafana Loki** (~300-500MB) - Log aggregation and storage
+- **Grafana** (~200-300MB) - Web UI for viewing/searching logs
+- **Promtail or Fluent-bit** (~128-256MB) - Log collection (keep existing fluent-bit)
+
+**Total memory: ~600-1000MB** (saves 1-2GB compared to ELK)
+
+### Why Loki?
+
+- **Designed for cloud-native**: Built specifically for Kubernetes environments
+- **Minimal indexing**: Only indexes metadata (labels), not full-text like Elasticsearch
+- **Compressed storage**: Stores logs as compressed chunks, reducing storage by 5-10x
+- **Low resource usage**: With 3-day retention, uses minimal memory and storage
+- **Excellent search**: Grafana provides powerful log search, filtering, and visualization
+- **Production-ready**: Mature, well-supported, widely adopted
+
+## Implementation Details
+
+### Loki Configuration (Minimal Resources)
+
+**Deployment mode:** Single-binary (not microservices)
+
+**Resource limits:**
+```yaml
+resources:
+  requests:
+    memory: 256Mi
+    cpu: 100m
+  limits:
+    memory: 512Mi
+    cpu: 500m
+```
+
+**Key configuration settings:**
+```yaml
+limits_config:
+  retention_period: 72h              # 3 days retention
+  max_query_lookback: 72h
+  ingestion_rate_mb: 4               # Limit ingestion to prevent spikes
+  ingestion_burst_size_mb: 6
+
+chunk_store_config:
+  max_look_back_period: 72h
+
+table_manager:
+  retention_deletes_enabled: true    # Auto-delete old logs
+  retention_period: 72h
+
+storage_config:
+  filesystem:
+    directory: /loki/chunks           # Local filesystem storage
+
+compactor:
+  working_directory: /loki/compactor
+  shared_store: filesystem
+  retention_enabled: true
+  retention_delete_delay: 2h
+```
+
+### Grafana Configuration
+
+**Resource limits:**
+```yaml
+resources:
+  requests:
+    memory: 128Mi
+    cpu: 100m
+  limits:
+    memory: 256Mi
+    cpu: 500m
+```
+
+**Data source:** Configure Loki as data source in Grafana
+
+### Fluent-bit Configuration
+
+**Keep existing fluent-bit DaemonSet** with updated output configuration:
+
+```yaml
+[OUTPUT]
+    Name loki
+    Match *
+    Host loki.revieu-prod.svc.cluster.local
+    Port 3100
+    Labels job=fluent-bit
+    Auto_kubernetes_labels on
+```
+
+## Migration Plan
+
+### Phase 1: Deploy Loki + Grafana (Parallel)
+1. Deploy Loki StatefulSet with minimal config
+2. Deploy Grafana Deployment
+3. Configure Grafana with Loki data source
+4. Update fluent-bit to send logs to BOTH Elasticsearch and Loki
+5. Verify logs appear in both systems
+
+**Duration:** Deploy and validate in parallel with existing stack
+
+### Phase 2: Validation (1-2 days)
+1. Use both systems in parallel
+2. Test typical debugging workflows in Grafana
+3. Verify all services' logs are captured
+4. Confirm search performance is acceptable
+5. Monitor Loki memory usage
+
+### Phase 3: Cutover
+1. Update fluent-bit config to send logs ONLY to Loki
+2. Remove Elasticsearch StatefulSet
+3. Remove Kibana Deployment
+4. Delete Elasticsearch PVCs to reclaim storage
+5. Monitor memory usage (should drop by 1-2GB)
+
+### Rollback Plan
+- Keep ELK configs in git for 2 weeks
+- If issues arise, redeploy ELK stack
+- Fluent-bit config change is the only switch needed
+
+## Alternative Approaches Considered
+
+### Option 2: Vector + File-based Logs
+- **Memory:** ~100-200MB
+- **Pros:** Minimal footprint; Vector is very efficient
+- **Cons:** Less sophisticated search; requires more manual work
+- **Rejected:** Need centralized aggregation for 4-10 services
+
+### Option 3: Dozzle (Docker-only)
+- **Memory:** ~50-100MB
+- **Pros:** Ultra-lightweight; zero config
+- **Cons:** No aggregation; limited search; Docker-only
+- **Rejected:** Not suitable for 4-10 services; need centralized solution
+
+## Expected Outcomes
+
+### Memory Savings
+- **Before:** 1.6-3.3GB (ELK stack)
+- **After:** 0.6-1.0GB (Loki + Grafana)
+- **Savings:** 1.0-2.3GB (30-70% reduction)
+
+### Storage Savings
+- Loki's compression reduces storage by 5-10x vs Elasticsearch
+- With 3-day retention, minimal storage needed (~1-2GB)
+
+### Operational Benefits
+- Faster log queries (less indexing overhead)
+- Simpler architecture (fewer moving parts)
+- Better Kubernetes integration
+- Lower resource contention on VPS
+
+## Success Criteria
+
+1. ✅ Total logging stack memory usage <1GB
+2. ✅ All service logs captured and searchable
+3. ✅ Log search response time <2 seconds for typical queries
+4. ✅ 3-day log retention working correctly
+5. ✅ Web UI accessible and functional
+6. ✅ VPS has sufficient free memory for applications
+
+## References
+
+- [Grafana Loki Documentation](https://grafana.com/docs/loki/latest/)
+- [Loki Configuration Reference](https://grafana.com/docs/loki/latest/configuration/)
+- [Fluent-bit Loki Output Plugin](https://docs.fluentbit.io/manual/pipeline/outputs/loki)

--- a/docs/plans/2026-02-01-logging-stack-migration.md
+++ b/docs/plans/2026-02-01-logging-stack-migration.md
@@ -1,0 +1,728 @@
+# Logging Stack Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Deploy Loki + Grafana in the `logging` namespace, dual-write from Fluent Bit, then cut over and remove Elasticsearch/Kibana while keeping 3-day retention and <1 GB memory.
+
+**Architecture:** Add Loki single-binary StatefulSet with filesystem storage and compactor retention; Grafana Deployment with a provisioned Loki datasource and Traefik ingress; Fluent Bit outputs to both ES and Loki during validation, then Loki-only at cutover.
+
+**Tech Stack:** Kubernetes + Kustomize, Grafana Loki, Grafana, Fluent Bit, Traefik ingress, cert-manager.
+
+**Assumptions/Decisions:**
+- Grafana hostname is `grafana.weijun.online` (match Kibana pattern). Update if different.
+- Loki and Grafana run in the existing `logging` namespace.
+- Images pinned to `grafana/loki:2.9.6` and `grafana/grafana:10.4.2` (update if you prefer).
+
+### Task 1: Create Loki base manifests
+
+**Files:**
+- Create: `apps/base/middleware/loki/kustomization.yaml`
+- Create: `apps/base/middleware/loki/configmap.yaml`
+- Create: `apps/base/middleware/loki/service.yaml`
+- Create: `apps/base/middleware/loki/statefulset.yaml`
+
+**Step 1: Write the failing test (kustomize references missing files)**
+
+```yaml
+# apps/base/middleware/loki/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: logging
+resources:
+  - configmap.yaml
+  - service.yaml
+  - statefulset.yaml
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `kustomize build apps/base/middleware/loki`
+Expected: FAIL with "no such file" for the missing manifests.
+
+**Step 3: Write minimal implementation (Loki config)**
+
+```yaml
+# apps/base/middleware/loki/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+    common:
+      path_prefix: /loki
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: boltdb-shipper
+          object_store: filesystem
+          schema: v11
+          index:
+            prefix: index_
+            period: 24h
+    storage_config:
+      boltdb_shipper:
+        active_index_directory: /loki/index
+        cache_location: /loki/index_cache
+        shared_store: filesystem
+      filesystem:
+        directory: /loki/chunks
+    limits_config:
+      retention_period: 72h
+      max_query_lookback: 72h
+      ingestion_rate_mb: 4
+      ingestion_burst_size_mb: 6
+    chunk_store_config:
+      max_look_back_period: 72h
+    table_manager:
+      retention_deletes_enabled: true
+      retention_period: 72h
+    compactor:
+      working_directory: /loki/compactor
+      shared_store: filesystem
+      retention_enabled: true
+      retention_delete_delay: 2h
+```
+
+**Step 4: Write minimal implementation (Service)**
+
+```yaml
+# apps/base/middleware/loki/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 3100
+      targetPort: http
+    - name: grpc
+      port: 9096
+      targetPort: grpc
+  selector:
+    app.kubernetes.io/name: loki
+```
+
+**Step 5: Write minimal implementation (StatefulSet)**
+
+```yaml
+# apps/base/middleware/loki/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: loki
+  labels:
+    app.kubernetes.io/name: loki
+    app.kubernetes.io/component: logging
+spec:
+  serviceName: loki
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: loki
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: loki
+        app.kubernetes.io/component: logging
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:2.9.6
+          args:
+            - -config.file=/etc/loki/loki.yaml
+          ports:
+            - name: http
+              containerPort: 3100
+            - name: grpc
+              containerPort: 9096
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/loki
+            - name: data
+              mountPath: /loki
+      volumes:
+        - name: config
+          configMap:
+            name: loki-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 10Gi
+```
+
+**Step 6: Run test to verify it passes**
+
+Run: `kustomize build apps/base/middleware/loki`
+Expected: PASS and output includes ConfigMap/Service/StatefulSet for Loki.
+
+**Step 7: Commit**
+
+```bash
+git add apps/base/middleware/loki
+git commit -m "feat: add loki base manifests"
+```
+
+### Task 2: Create Grafana base manifests
+
+**Files:**
+- Create: `apps/base/middleware/grafana/kustomization.yaml`
+- Create: `apps/base/middleware/grafana/configmap-datasources.yaml`
+- Create: `apps/base/middleware/grafana/pvc.yaml`
+- Create: `apps/base/middleware/grafana/deployment.yaml`
+- Create: `apps/base/middleware/grafana/service.yaml`
+- Create: `apps/base/middleware/grafana/ingress.yaml`
+- Create: `apps/base/middleware/grafana/certificate.yaml`
+
+**Step 1: Write the failing test (kustomize references missing files)**
+
+```yaml
+# apps/base/middleware/grafana/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: logging
+resources:
+  - configmap-datasources.yaml
+  - pvc.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  - certificate.yaml
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `kustomize build apps/base/middleware/grafana`
+Expected: FAIL with "no such file" for the missing manifests.
+
+**Step 3: Write minimal implementation (datasource + storage)**
+
+```yaml
+# apps/base/middleware/grafana/configmap-datasources.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-datasources
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+data:
+  datasources.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Loki
+        type: loki
+        access: proxy
+        url: http://loki.logging.svc.cluster.local:3100
+        isDefault: true
+        editable: false
+```
+
+```yaml
+# apps/base/middleware/grafana/pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grafana-storage
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 5Gi
+```
+
+**Step 4: Write minimal implementation (Deployment + Service)**
+
+```yaml
+# apps/base/middleware/grafana/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana
+        app.kubernetes.io/component: logging
+    spec:
+      containers:
+        - name: grafana
+          image: grafana/grafana:10.4.2
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: GF_SECURITY_ADMIN_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: admin-user
+            - name: GF_SECURITY_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-admin
+                  key: admin-password
+            - name: GF_SERVER_ROOT_URL
+              value: "https://grafana.weijun.online"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          volumeMounts:
+            - name: datasources
+              mountPath: /etc/grafana/provisioning/datasources
+            - name: storage
+              mountPath: /var/lib/grafana
+      volumes:
+        - name: datasources
+          configMap:
+            name: grafana-datasources
+        - name: storage
+          persistentVolumeClaim:
+            claimName: grafana-storage
+```
+
+```yaml
+# apps/base/middleware/grafana/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  labels:
+    app.kubernetes.io/name: grafana
+    app.kubernetes.io/component: logging
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/name: grafana
+```
+
+**Step 5: Write minimal implementation (Ingress + Certificate)**
+
+```yaml
+# apps/base/middleware/grafana/certificate.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grafana-cert
+spec:
+  secretName: grafana-tls-secret
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+    - "grafana.weijun.online"
+```
+
+```yaml
+# apps/base/middleware/grafana/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  annotations:
+    kubernetes.io/ingress.class: traefik
+spec:
+  tls:
+    - hosts:
+        - grafana.weijun.online
+      secretName: grafana-tls-secret
+  rules:
+    - host: grafana.weijun.online
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 80
+```
+
+**Step 6: Run test to verify it passes**
+
+Run: `kustomize build apps/base/middleware/grafana`
+Expected: PASS and output includes Grafana Deployment/Service/Ingress/Certificate/PVC/ConfigMap.
+
+**Step 7: Commit**
+
+```bash
+git add apps/base/middleware/grafana
+git commit -m "feat: add grafana base manifests"
+```
+
+### Task 3: Add Grafana admin secret in prod overlay
+
+**Files:**
+- Create: `apps/overlays/prod/middleware/grafana/kustomization.yaml`
+- Create: `apps/overlays/prod/middleware/grafana/secret.yaml`
+
+**Step 1: Write the failing test (kustomize references missing secret)**
+
+```yaml
+# apps/overlays/prod/middleware/grafana/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../../base/middleware/grafana
+  - secret.yaml
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `kustomize build apps/overlays/prod/middleware/grafana`
+Expected: FAIL with "no such file" for `secret.yaml`.
+
+**Step 3: Write minimal implementation (secret with initial credentials)**
+
+```yaml
+# apps/overlays/prod/middleware/grafana/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-admin
+  namespace: logging
+type: Opaque
+stringData:
+  admin-user: admin
+  admin-password: change-me-please
+```
+
+**Step 4: Run test to verify it passes**
+
+Run: `kustomize build apps/overlays/prod/middleware/grafana`
+Expected: PASS and output includes Secret `grafana-admin`.
+
+**Step 5: Commit**
+
+```bash
+git add apps/overlays/prod/middleware/grafana
+git commit -m "feat: add grafana admin secret for prod"
+```
+
+### Task 4: Wire Loki + Grafana into middleware kustomizations
+
+**Files:**
+- Modify: `apps/base/middleware/kustomization.yaml`
+- Modify: `apps/overlays/prod/middleware/kustomization.yaml`
+
+**Step 1: Write the failing test (base kustomize missing new resources)**
+
+Run: `kustomize build apps/base/middleware | rg -n "loki|grafana" -S`
+Expected: FAIL with no Loki/Grafana resources in output.
+
+**Step 2: Write minimal implementation (base middleware kustomization)**
+
+```yaml
+# apps/base/middleware/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager/
+  - fluent-bit/
+  - kibana/
+  - loki/
+  - grafana/
+  - traefik/
+  - sealed-secrets/
+```
+
+**Step 3: Run test to verify it passes**
+
+Run: `kustomize build apps/base/middleware | rg -n "loki|grafana" -S`
+Expected: PASS with Loki/Grafana resources present.
+
+**Step 4: Write minimal implementation (prod middleware kustomization)**
+
+```yaml
+# apps/overlays/prod/middleware/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager/
+  - fluent-bit/
+  - kibana/
+  - loki/
+  - grafana/
+  - traefik/
+  - sealed-secrets/
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `kustomize build apps/overlays/prod/middleware | rg -n "loki|grafana" -S`
+Expected: PASS with Loki/Grafana resources present.
+
+**Step 6: Commit**
+
+```bash
+git add apps/base/middleware/kustomization.yaml apps/overlays/prod/middleware/kustomization.yaml
+git commit -m "feat: wire loki and grafana into middleware kustomize"
+```
+
+### Task 5: Update Fluent Bit for dual-write (ES + Loki)
+
+**Files:**
+- Modify: `apps/base/middleware/fluent-bit/configmap.yaml`
+
+**Step 1: Write the failing test (current config missing Loki output)**
+
+Run: `kustomize build apps/base/middleware/fluent-bit | rg -n "Name\\s+loki" -S`
+Expected: FAIL with no Loki output in the ConfigMap.
+
+**Step 2: Write minimal implementation (add Loki output block)**
+
+```yaml
+# apps/base/middleware/fluent-bit/configmap.yaml (append after ES output)
+    [OUTPUT]
+        Name            loki
+        Match           *
+        Host            loki.logging.svc.cluster.local
+        Port            3100
+        Labels          job=fluent-bit
+        Auto_Kubernetes_Labels on
+```
+
+**Step 3: Run test to verify it passes**
+
+Run: `kustomize build apps/base/middleware/fluent-bit | rg -n "Name\\s+loki" -S`
+Expected: PASS with Loki output present.
+
+**Step 4: Commit**
+
+```bash
+git add apps/base/middleware/fluent-bit/configmap.yaml
+git commit -m "feat: send fluent-bit logs to loki in parallel"
+```
+
+### Task 6: Deploy Loki + Grafana in parallel and validate
+
+**Files:**
+- Modify: none (operational)
+
+**Step 1: Apply middleware overlay**
+
+Run: `kubectl apply -k apps/overlays/prod/middleware`
+Expected: `configured`/`created` resources for Loki/Grafana.
+
+**Step 2: Verify rollout**
+
+Run: `kubectl -n logging rollout status statefulset/loki`
+Expected: `statefulset "loki" successfully rolled out`
+
+Run: `kubectl -n logging rollout status deployment/grafana`
+Expected: `deployment "grafana" successfully rolled out`
+
+**Step 3: Confirm Loki is ingesting logs**
+
+Run: `kubectl -n logging port-forward svc/grafana 3000:80`
+Expected: Grafana UI reachable at `http://localhost:3000`, Loki datasource present, logs visible in Explore.
+
+**Step 4: Commit**
+
+No commit (operational validation only).
+
+### Task 7: Cutover to Loki-only and remove ELK
+
+**Files:**
+- Modify: `apps/base/middleware/fluent-bit/configmap.yaml`
+- Modify: `apps/base/middleware/kustomization.yaml`
+- Modify: `apps/overlays/prod/middleware/kustomization.yaml`
+- Modify: `apps/base/apps/kustomization.yaml`
+- Modify: `apps/overlays/prod/kustomization.yaml`
+
+**Step 1: Write the failing test (ES output still present)**
+
+Run: `kustomize build apps/base/middleware/fluent-bit | rg -n "Name\\s+es" -S`
+Expected: PASS (ES output still present) — this is the "fail" signal.
+
+**Step 2: Write minimal implementation (remove ES output block)**
+
+Remove this block from `apps/base/middleware/fluent-bit/configmap.yaml`:
+
+```yaml
+    [OUTPUT]
+        Name            es
+        Match           *
+        Host            elasticsearch.revieu-prod.svc.cluster.local
+        Port            9200
+        Logstash_Format On
+        Retry_Limit     False
+        Replace_Dots    On
+        Suppress_Type_Name On
+```
+
+**Step 3: Run test to verify it passes**
+
+Run: `kustomize build apps/base/middleware/fluent-bit | rg -n "Name\\s+es" -S`
+Expected: FAIL (no ES output found).
+
+**Step 4: Write minimal implementation (stop deploying Kibana + Elasticsearch)**
+
+```yaml
+# apps/base/middleware/kustomization.yaml (remove kibana/)
+resources:
+  - cert-manager/
+  - fluent-bit/
+  - loki/
+  - grafana/
+  - traefik/
+  - sealed-secrets/
+```
+
+```yaml
+# apps/overlays/prod/middleware/kustomization.yaml (remove kibana/)
+resources:
+  - cert-manager/
+  - fluent-bit/
+  - loki/
+  - grafana/
+  - traefik/
+  - sealed-secrets/
+```
+
+```yaml
+# apps/base/apps/kustomization.yaml (remove elasticsearch/)
+resources:
+  - auth/
+  - web/
+```
+
+```yaml
+# apps/overlays/prod/kustomization.yaml (remove apps/elasticsearch)
+resources:
+  - ./common
+  - ./apps/auth
+  - ./apps/web
+  - ./external/postgres
+  - ./middleware
+```
+
+**Step 5: Run test to verify it passes**
+
+Run: `kustomize build apps/overlays/prod | rg -n "elasticsearch|kibana" -S`
+Expected: FAIL (no Elasticsearch/Kibana resources found).
+
+**Step 6: Commit**
+
+```bash
+git add apps/base/middleware/fluent-bit/configmap.yaml \
+  apps/base/middleware/kustomization.yaml \
+  apps/overlays/prod/middleware/kustomization.yaml \
+  apps/base/apps/kustomization.yaml \
+  apps/overlays/prod/kustomization.yaml
+git commit -m "feat: cut over logging to loki and remove elk from kustomize"
+```
+
+**Step 7: Apply cutover and clean up PVCs**
+
+Run: `kubectl apply -k apps/overlays/prod/middleware`
+Expected: Fluent Bit reloads config and continues shipping to Loki only.
+
+Run: `kubectl apply -k apps/overlays/prod`
+Expected: Elasticsearch + Kibana resources are removed.
+
+Run: `kubectl get pvc -A | rg -n "elasticsearch" -S`
+Expected: Identify the Elasticsearch PVC(s), then delete them explicitly:
+
+```bash
+kubectl delete pvc -n <namespace> <elasticsearch-pvc-name>
+```
+
+### Task 8: Post-cutover validation + rollback window
+
+**Files:**
+- Modify: none (operational)
+
+**Step 1: Validate log search workflows**
+
+Run: `kubectl -n logging port-forward svc/grafana 3000:80`
+Expected: Grafana Explore returns recent logs for multiple services within 2 seconds.
+
+**Step 2: Validate memory savings**
+
+Run: `kubectl -n logging top pod | rg -n "loki|grafana|fluent-bit" -S`
+Expected: Combined memory usage < 1 GiB.
+
+**Step 3: Keep rollback-ready configs for 14 days**
+
+Do not delete the `apps/base/middleware/kibana` or `apps/base/apps/elasticsearch` directories yet.
+If rollback needed, re-add the resources in kustomizations and revert the Fluent Bit output.
+
+**Step 4: Optional cleanup after 14 days**
+
+If no rollback needed, delete:
+- `apps/base/middleware/kibana`
+- `apps/overlays/prod/middleware/kibana`
+- `apps/base/apps/elasticsearch`
+- `apps/overlays/prod/apps/elasticsearch`
+
+Commit cleanup with:
+
+```bash
+git rm -r apps/base/middleware/kibana apps/overlays/prod/middleware/kibana \
+  apps/base/apps/elasticsearch apps/overlays/prod/apps/elasticsearch
+git commit -m "chore: remove deprecated elk manifests"
+```


### PR DESCRIPTION
## Summary
  - add Loki StatefulSet + config and Grafana deployment with datasource provisioning
  - wire Loki/Grafana into middleware kustomizations and add Grafana admin secret
  - switch Fluent Bit to Loki-only and remove ELK from kustomize resources

  ## Test Plan
  - [ ] kustomize build apps/base/middleware/loki
  - [ ] kustomize build apps/base/middleware/grafana
  - [ ] kustomize build apps/overlays/prod/middleware
  - [ ] kustomize build apps/overlays/prod